### PR TITLE
Yaml schema cross-org

### DIFF
--- a/subworkflows/nf-core-test/fastq_trim_fastp_fastqc/meta.yml
+++ b/subworkflows/nf-core-test/fastq_trim_fastp_fastqc/meta.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/refs/heads/main/subworkflows/yaml-schema.json
 name: "fastq_trim_fastp_fastqc"
 description: Read QC, fastp trimming and read qc
 keywords:

--- a/subworkflows/nf-core-test/fastq_trim_fastp_fastqc/meta.yml
+++ b/subworkflows/nf-core-test/fastq_trim_fastp_fastqc/meta.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/refs/heads/main/subworkflows/yaml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/main/subworkflows/yaml-schema.json
 name: "fastq_trim_fastp_fastqc"
 description: Read QC, fastp trimming and read qc
 keywords:

--- a/subworkflows/nf-core-test/get_genome_annotation/meta.yml
+++ b/subworkflows/nf-core-test/get_genome_annotation/meta.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/subworkflows/yaml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/refs/heads/main/subworkflows/yaml-schema.json
 name: get_genome_annotation
 description: Placeholder
 keywords:

--- a/subworkflows/nf-core-test/get_genome_annotation/meta.yml
+++ b/subworkflows/nf-core-test/get_genome_annotation/meta.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/refs/heads/main/subworkflows/yaml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/main/subworkflows/yaml-schema.json
 name: get_genome_annotation
 description: Placeholder
 keywords:


### PR DESCRIPTION
Hiya,

Another typo. The `meta.yml` files should have their header lines point at the modified yaml-schema (the one that says we can object for components). This header line is used by some IDEs and validation tools, it's useful to get it right.

Cheers,
Matthieu