### PR TITLE
Added a sub-workflow entirely made of nf-core modules

### DIFF
--- a/subworkflows/nf-core-test/wget_subwf/main.nf
+++ b/subworkflows/nf-core-test/wget_subwf/main.nf
@@ -1,0 +1,22 @@
+include { WGET      } from '../../../modules/nf-core/wget/main'
+
+workflow WGET_SUBWF {
+    take:
+    urls     // Channel: tuple [ val(meta), val( url )      ]
+
+    main:
+    ch_versions         = Channel.empty()
+
+    // Download file
+    WGET {
+        urls
+    }
+
+    }
+    ch_versions = ch_versions.mix(WGET.out.versions.first().ifEmpty(null))
+
+    emit:
+    outfile     = WGET.out.outfile
+    versions    = ch_versions.ifEmpty(null)
+}
+

--- a/subworkflows/nf-core-test/wget_subwf/meta.yml
+++ b/subworkflows/nf-core-test/wget_subwf/meta.yml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core-test/modules/main/subworkflows/yaml-schema.json
+name: wget_subwf
+description: Dummy subworkflow that only uses nf-core modules. Used to test https://github.com/nf-core/tools/issues/3876
+keywords:
+  - download
+components:
+  - wget:
+      git_remote: https://github.com/nf-core/modules.git
+input:
+  - urls:
+      description: |
+        Placeholder
+output:
+  - outfile:
+      description: |
+        Placeholder
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+authors:
+  - "@sanger-tol"
+


### PR DESCRIPTION
This is the minimal example to reproduce the error described in https://github.com/nf-core/tools/issues/3876

Install the sub-workflow twice and notice how a spurious entry gets added to `modules.json`.

```console
$ nf-core subworkflows --git-remote https://github.com/nf-core-test/modules.git --branch test_nf-core_only_subwf install wget_subwf
(...)
INFO     Installing 'wget_subwf'
(...)
$ jq '.repos."https://github.com/nf-core-test/modules.git".subworkflows."nf-core-test".wget_subwf' < modules.json
{
  "branch": "test_nf-core_only_subwf",
  "git_sha": "162933bb3315b96321263fdc657389061ca16d7b",
  "installed_by": [
    "subworkflows"
  ]
}
$ jq '.repos."https://github.com/nf-core/modules.git".subworkflows."nf-core".wget_subwf' < modules.json 
null

$ nf-core subworkflows --git-remote https://github.com/nf-core-test/modules.git --branch test_nf-core_only_subwf install wget_subwf
(...)
INFO     Subworkflow 'wget_subwf' is already installed.
(...)
$ jq '.repos."https://github.com/nf-core/modules.git".subworkflows."nf-core".wget_subwf' < modules.json 
{
  "branch": "master",
  "git_sha": "162933bb3315b96321263fdc657389061ca16d7b",
  "installed_by": [
    "subworkflows"
  ]
}
$ jq '.repos."https://github.com/nf-core-test/modules.git".subworkflows."nf-core-test".wget_subwf' < modules.json 
{
  "branch": "test_nf-core_only_subwf",
  "git_sha": "162933bb3315b96321263fdc657389061ca16d7b",
  "installed_by": [
    "subworkflows"
  ]
}
```

Actually, the existing sub-workflows of this repository (`fastq_trim_fastp_fastqc` and `get_genome_annotation`) suffice to reproduce the bug (trying installing them twice like I did). But I believe it only works because their modules are installed in a particular order,  and I can't entirely explain what this order is, nor can I guarantee it will remain the same in the future. That's why I prefer adding another sub-workflow with an explicit link to the GitHub issue.